### PR TITLE
Remove facebook and twitter logos

### DIFF
--- a/_includes/get_involved.html
+++ b/_includes/get_involved.html
@@ -142,8 +142,7 @@ how you can get involved with a project or with organizing Open Twin Cities.
     </p>
     <p>
       Open Twin Cities has media tools to help you share news, including an
-      email list of 500+, a Meetup of 350+, 900+ followers on Twitter, as well
-      as active Facebook, Youtube, and Flickr accounts.
+      email list of 500+ and a Meetup of 650+.
     </p>
     <p>
       Helping to share news can be as simple as sending some tweets or as 

--- a/_includes/online_presence.html
+++ b/_includes/online_presence.html
@@ -2,6 +2,4 @@
   <li><a href="https://groups.google.com/forum/#!forum/twin-cities-brigade" data-social-network='Google Group' data-social-action='visit'><i class="fi-torsos-all" title="Google Group"></i></a></li>
   <li><a href="https://otc-slackin.herokuapp.com/" data-social-network='Slack' data-social-action='visit'><i class="fa fa-slack" title="Slack"></i></a></li>
   <li><a href="https://github.com/opentwincities" data-social-network='GitHub' data-social-action='visit'><i class="fi-social-github" title="GitHub"></i></a></li>
-  <li><a href="https://twitter.com/OpenTwinCities" data-social-network='Twitter' data-social-action='visit'><i class="fi-social-twitter" title="Twitter"></i></a></li>
-  <li><a href="https://www.facebook.com/OpenTwinCities" data-social-network='Facebook' data-social-action='visit'><i class="fi-social-facebook" title="Facebook"></i></a></li>
 </ul>


### PR DESCRIPTION
Closes #59 

I removed the facebook and twitter logos from the Online Presence box on the main page. 
I also removed the mention of our Facebook and Twitter accounts on the Get Involved page, since those accounts are no longer actively updated.
