### PR TITLE
Update to Font Awesome 5 and change to brand icon

### DIFF
--- a/_includes/online_presence.html
+++ b/_includes/online_presence.html
@@ -1,6 +1,6 @@
 <ul class="no-bullet joinuslinks">
   <li><a href="https://groups.google.com/forum/#!forum/twin-cities-brigade" data-social-network='Google Group' data-social-action='visit'><i class="fi-torsos-all" title="Google Group"></i></a></li>
-  <li><a href="https://otc-slackin.herokuapp.com/" data-social-network='Slack' data-social-action='visit'><i class="fa fa-slack" title="Slack"></i></a></li>
+  <li><a href="https://otc-slackin.herokuapp.com/" data-social-network='Slack' data-social-action='visit'><i class="fab fa-slack" title="Slack"></i></a></li>
   <li><a href="https://github.com/opentwincities" data-social-network='GitHub' data-social-action='visit'><i class="fi-social-github" title="GitHub"></i></a></li>
   <li><a href="https://twitter.com/OpenTwinCities" data-social-network='Twitter' data-social-action='visit'><i class="fi-social-twitter" title="Twitter"></i></a></li>
   <li><a href="https://www.facebook.com/OpenTwinCities" data-social-network='Facebook' data-social-action='visit'><i class="fi-social-facebook" title="Facebook"></i></a></li>

--- a/_includes/std_head.html
+++ b/_includes/std_head.html
@@ -44,7 +44,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.1.1/css/normalize.min.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.1.1/css/foundation.min.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css"/>
     <link rel="stylesheet" type="text/css" href="/css/site.css"/>
 
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} Posts" href="{{ site.url }}feed.xml">


### PR DESCRIPTION
Fixes #58 
Slack icon not available in Foundation Icon Fonts 3 and Zurb hasn't created a newer version of the Foundation Icon Fonts. 
So update to v5 for the most recent Font Awesome icons instead, and use the FA Brand slack icon from there. 